### PR TITLE
Remove 'disableInitialLoad' to re-enable single request mode

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -41,9 +41,6 @@ var service = once(function(options) {
 
 function initDfp(googletag) {
   googletag.pubads().enableSingleRequest()
-  // Infinite scroll ad
-  // @see https://support.google.com/dfp_sb/answer/4623874
-  googletag.pubads().disableInitialLoad()
   googletag.enableServices()
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-simple-dfp",
-  "version": "1.3.0",
+  "version": "2.0.0-beta",
   "description": "A simple React component for DFP - DoubleClick for Publishers based on @amobiz/react-simple-dfp.",
   "main": "lib/component.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-simple-dfp",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "A simple React component for DFP - DoubleClick for Publishers based on @amobiz/react-simple-dfp.",
   "main": "lib/component.js",
   "scripts": {


### PR DESCRIPTION
From an ad-tech review, we want to be using Single Request Mode, for ad-load performance.
We have SRM enabled, but immediately follow it up with disabling initial load.

Undoing this so it can be packaged & tested.