### PR TITLE
[RENT-4207] Implement single slot refresh

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -115,6 +115,12 @@ function dfp(options) {
         window.eventBus.subscribe('refresh_all_ads', function() {
           googletag.pubads().refresh([slot])
         })
+
+        window.eventBus.subscribe('refresh_ad_slot', function (adKey) {
+          if (slot.getSlotElementId() == adKey) {
+            googletag.pubads().refresh([slot])
+          }
+        })
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/react-simple-dfp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A simple React component for DFP - DoubleClick for Publishers based on @amobiz/react-simple-dfp.",
   "main": "lib/component.js",
   "scripts": {


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/RENT-4207)

This PR has a sister PR for Rent-JS here: https://github.com/rentpath/rent-js/pull/4899

Sets up a new listener on all ad slots for refreshing just one slot instead of _all_ slots.